### PR TITLE
Add targeted Send support via destination URI overloads

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -16,8 +16,8 @@
         <PackageIcon>pandatech.png</PackageIcon>
         <PackageReadmeFile>README.md</PackageReadmeFile>
 
-        <Version>6.0.0</Version>
-        <PackageReleaseNotes>Replace SQLite package with provider-agnostic EF Core outbox package; fix inbox retry duplicate dispatch and failed message cleanup</PackageReleaseNotes>
+        <Version>7.0.0</Version>
+        <PackageReleaseNotes>Add targeted Send support: new AddToOutbox overloads accepting destination URI for direct endpoint delivery instead of fan-out Publish. Breaking change: new DestinationAddress column on OutboxMessages table requires a migration.</PackageReleaseNotes>
 
         <!-- Build quality -->
         <TreatWarningsAsErrors>false</TreatWarningsAsErrors>

--- a/README.md
+++ b/README.md
@@ -154,6 +154,35 @@ Both methods return the generated outbox message ID(s) for correlation if needed
 
 The background publisher picks up new messages, publishes them via MassTransit, and marks them as done.
 
+### 3a. Send to specific endpoints (targeted delivery)
+
+When you need to deliver a message to a specific endpoint rather than broadcasting to all subscribers, use the
+`AddToOutbox` overloads that accept a destination `Uri`. The background publisher will use MassTransit `Send` instead of
+`Publish` for these messages.
+
+**Single destination:**
+
+```csharp
+dbContext.AddToOutbox(
+    new ConfigUpdatedEvent { DeviceId = deviceId },
+    new Uri("queue:device-42"));
+
+await dbContext.SaveChangesAsync();
+```
+
+**Multiple destinations (same message):**
+
+```csharp
+var destinations = deviceIds.Select(id => new Uri($"queue:device-{id}"));
+
+dbContext.AddToOutbox(new ConfigUpdatedEvent { Version = 5 }, destinations);
+
+await dbContext.SaveChangesAsync();
+```
+
+One outbox row is created per destination. All rows share the same serialized payload and are delivered independently.
+Messages without a destination continue to use `Publish` — existing code is unaffected.
+
 ### 4. Consume messages (inbox)
 
 Create a consumer that inherits from `InboxConsumer<TMessage, TDbContext>`:
@@ -184,8 +213,8 @@ The base class handles deduplication (by `MessageId` + `ConsumerId`) and concurr
 ### Outbox flow
 
 Your code calls `AddToOutbox()` + `SaveChangesAsync()` → the message is persisted in the `OutboxMessages` table
-atomically with your domain changes → a background `HostedService` polls for new messages, publishes them via
-MassTransit, and marks them as done → a cleanup service deletes old processed messages.
+atomically with your domain changes → a background `HostedService` polls for new messages, publishes (or sends, when a
+destination is specified) them via MassTransit, and marks them as done → a cleanup service deletes old processed messages.
 
 ### Inbox flow
 

--- a/src/MassTransit.EfCoreOutbox/Entities/OutboxMessage.cs
+++ b/src/MassTransit.EfCoreOutbox/Entities/OutboxMessage.cs
@@ -28,6 +28,12 @@ public class OutboxMessage
    public required string Type { get; set; }
 
    /// <summary>
+   ///    Optional destination endpoint address. When set, the message is sent directly
+   ///    to this endpoint instead of being published to all subscribers.
+   /// </summary>
+   public string? DestinationAddress { get; set; }
+
+   /// <summary>
    ///    Timestamp when the message was added to the outbox.
    /// </summary>
    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;

--- a/src/MassTransit.EfCoreOutbox/Extensions/OutboxDbContextExtensions.cs
+++ b/src/MassTransit.EfCoreOutbox/Extensions/OutboxDbContextExtensions.cs
@@ -61,6 +61,65 @@ public static class OutboxDbContextExtensions
    }
 
    /// <summary>
+   ///    Adds a message to the outbox targeted at a specific endpoint. The background publisher
+   ///    will use MassTransit <c>Send</c> instead of <c>Publish</c> for this message.
+   /// </summary>
+   /// <typeparam name="T">The message type. Must be serializable by <see cref="System.Text.Json" />.</typeparam>
+   /// <param name="dbContext">The DbContext implementing <see cref="IOutboxDbContext" />.</param>
+   /// <param name="message">The message to enqueue.</param>
+   /// <param name="destination">The target endpoint URI (e.g. <c>new Uri("queue:my-endpoint")</c>).</param>
+   /// <returns>The generated outbox message ID, usable for correlation or diagnostics.</returns>
+   public static Guid AddToOutbox<T>(this IOutboxDbContext dbContext, T message, Uri destination)
+   {
+      var entity = new OutboxMessage
+      {
+         CreatedAt = DateTime.UtcNow,
+         State = MessageState.New,
+         UpdatedAt = null,
+         Payload = JsonSerializer.Serialize(message),
+         Type = GetVersionAgnosticTypeName<T>(),
+         DestinationAddress = destination.ToString()
+      };
+
+      dbContext.OutboxMessages.Add(entity);
+
+      return entity.Id;
+   }
+
+   /// <summary>
+   ///    Adds a message to the outbox for each specified destination endpoint. The background publisher
+   ///    will use MassTransit <c>Send</c> instead of <c>Publish</c> for these messages.
+   ///    All messages share the same <c>CreatedAt</c> timestamp and serialized payload.
+   /// </summary>
+   /// <typeparam name="T">The message type. Must be serializable by <see cref="System.Text.Json" />.</typeparam>
+   /// <param name="dbContext">The DbContext implementing <see cref="IOutboxDbContext" />.</param>
+   /// <param name="message">The message to enqueue.</param>
+   /// <param name="destinations">The target endpoint URIs (e.g. <c>new Uri("queue:my-endpoint")</c>).</param>
+   /// <returns>The generated outbox message IDs in the same order as <paramref name="destinations" />.</returns>
+   public static IReadOnlyList<Guid> AddToOutbox<T>(this IOutboxDbContext dbContext, T message,
+      IEnumerable<Uri> destinations)
+   {
+      var utcNow = DateTime.UtcNow;
+      var typeName = GetVersionAgnosticTypeName<T>();
+      var payload = JsonSerializer.Serialize(message);
+
+      var entities = destinations.Select(destination => new OutboxMessage
+                                  {
+                                     CreatedAt = utcNow,
+                                     State = MessageState.New,
+                                     UpdatedAt = null,
+                                     Payload = payload,
+                                     Type = typeName,
+                                     DestinationAddress = destination.ToString()
+                                  })
+                                  .ToArray();
+
+      dbContext.OutboxMessages.AddRange(entities);
+
+      return Array.ConvertAll(entities, e => e.Id);
+   }
+
+   /// <summary>
    ///    Returns "Namespace.TypeName, AssemblyName" without version/culture/token.
    ///    Type.GetType() resolves this format regardless of strong naming.
    /// </summary>

--- a/src/MassTransit.EfCoreOutbox/Jobs/OutboxMessagePublisherService.cs
+++ b/src/MassTransit.EfCoreOutbox/Jobs/OutboxMessagePublisherService.cs
@@ -84,10 +84,21 @@ internal class OutboxMessagePublisherService<TDbContext>(
 
                   var messageObject = JsonSerializer.Deserialize(message.Payload, type);
 
-                  await bus.Publish(messageObject!,
-                     type,
-                     x => x.Headers.Set(Constants.OutboxMessageIdHeaderName, message.Id),
-                     stoppingToken);
+                  if (message.DestinationAddress is not null)
+                  {
+                     var endpoint = await bus.GetSendEndpoint(new Uri(message.DestinationAddress));
+                     await endpoint.Send(messageObject!,
+                        type,
+                        x => x.Headers.Set(Constants.OutboxMessageIdHeaderName, message.Id),
+                        stoppingToken);
+                  }
+                  else
+                  {
+                     await bus.Publish(messageObject!,
+                        type,
+                        x => x.Headers.Set(Constants.OutboxMessageIdHeaderName, message.Id),
+                        stoppingToken);
+                  }
 
                   publishedMessageIds.Add(message.Id);
                }

--- a/src/MassTransit.PostgresOutbox/Entities/OutboxMessage.cs
+++ b/src/MassTransit.PostgresOutbox/Entities/OutboxMessage.cs
@@ -8,6 +8,7 @@ public class OutboxMessage
    public MessageState State { get; set; } = MessageState.New;
    public required string Payload { get; set; }
    public required string Type { get; set; }
+   public string? DestinationAddress { get; set; }
    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
    public DateTime? UpdatedAt { get; set; }
 }

--- a/src/MassTransit.PostgresOutbox/Extensions/OutboxDbContextExtensions.cs
+++ b/src/MassTransit.PostgresOutbox/Extensions/OutboxDbContextExtensions.cs
@@ -61,6 +61,65 @@ public static class OutboxDbContextExtensions
    }
 
    /// <summary>
+   ///    Adds a message to the outbox targeted at a specific endpoint. The background publisher
+   ///    will use MassTransit <c>Send</c> instead of <c>Publish</c> for this message.
+   /// </summary>
+   /// <typeparam name="T">The message type. Must be serializable by <see cref="System.Text.Json" />.</typeparam>
+   /// <param name="dbContext">The DbContext implementing <see cref="IOutboxDbContext" />.</param>
+   /// <param name="message">The message to enqueue.</param>
+   /// <param name="destination">The target endpoint URI (e.g. <c>new Uri("queue:my-endpoint")</c>).</param>
+   /// <returns>The generated outbox message ID, usable for correlation or diagnostics.</returns>
+   public static Guid AddToOutbox<T>(this IOutboxDbContext dbContext, T message, Uri destination)
+   {
+      var entity = new OutboxMessage
+      {
+         CreatedAt = DateTime.UtcNow,
+         State = MessageState.New,
+         UpdatedAt = null,
+         Payload = JsonSerializer.Serialize(message),
+         Type = GetVersionAgnosticTypeName<T>(),
+         DestinationAddress = destination.ToString()
+      };
+
+      dbContext.OutboxMessages.Add(entity);
+
+      return entity.Id;
+   }
+
+   /// <summary>
+   ///    Adds a message to the outbox for each specified destination endpoint. The background publisher
+   ///    will use MassTransit <c>Send</c> instead of <c>Publish</c> for these messages.
+   ///    All messages share the same <c>CreatedAt</c> timestamp and serialized payload.
+   /// </summary>
+   /// <typeparam name="T">The message type. Must be serializable by <see cref="System.Text.Json" />.</typeparam>
+   /// <param name="dbContext">The DbContext implementing <see cref="IOutboxDbContext" />.</param>
+   /// <param name="message">The message to enqueue.</param>
+   /// <param name="destinations">The target endpoint URIs (e.g. <c>new Uri("queue:my-endpoint")</c>).</param>
+   /// <returns>The generated outbox message IDs in the same order as <paramref name="destinations" />.</returns>
+   public static IReadOnlyList<Guid> AddToOutbox<T>(this IOutboxDbContext dbContext, T message,
+      IEnumerable<Uri> destinations)
+   {
+      var utcNow = DateTime.UtcNow;
+      var typeName = GetVersionAgnosticTypeName<T>();
+      var payload = JsonSerializer.Serialize(message);
+
+      var entities = destinations.Select(destination => new OutboxMessage
+                                  {
+                                     CreatedAt = utcNow,
+                                     State = MessageState.New,
+                                     UpdatedAt = null,
+                                     Payload = payload,
+                                     Type = typeName,
+                                     DestinationAddress = destination.ToString()
+                                  })
+                                  .ToArray();
+
+      dbContext.OutboxMessages.AddRange(entities);
+
+      return Array.ConvertAll(entities, e => e.Id);
+   }
+
+   /// <summary>
    ///    Returns "Namespace.TypeName, AssemblyName" without version/culture/token.
    ///    Type.GetType() resolves this format regardless of strong naming.
    ///    Backward compatible: old AssemblyQualifiedName rows still resolve fine.

--- a/src/MassTransit.PostgresOutbox/Jobs/OutboxMessagePublisherService.cs
+++ b/src/MassTransit.PostgresOutbox/Jobs/OutboxMessagePublisherService.cs
@@ -65,10 +65,21 @@ internal class OutboxMessagePublisherService<TDbContext>(
 
                      var messageObject = JsonSerializer.Deserialize(message.Payload, type);
 
-                     await bus.Publish(messageObject!,
-                        type,
-                        x => x.Headers.Set(Constants.OutboxMessageIdHeaderName, message.Id),
-                        stoppingToken);
+                     if (message.DestinationAddress is not null)
+                     {
+                        var endpoint = await bus.GetSendEndpoint(new Uri(message.DestinationAddress));
+                        await endpoint.Send(messageObject!,
+                           type,
+                           x => x.Headers.Set(Constants.OutboxMessageIdHeaderName, message.Id),
+                           stoppingToken);
+                     }
+                     else
+                     {
+                        await bus.Publish(messageObject!,
+                           type,
+                           x => x.Headers.Set(Constants.OutboxMessageIdHeaderName, message.Id),
+                           stoppingToken);
+                     }
 
                      publishedMessageIds.Add(message.Id);
                   }


### PR DESCRIPTION
New AddToOutbox overloads accept a destination Uri for direct endpoint delivery (MassTransit Send) instead of fan-out Publish. The background publisher routes based on the nullable DestinationAddress column. Breaking: new column on OutboxMessages requires a migration. Bump to v7.0.0.

Authored-By: Haik Asatryan (assisted by Claude Opus 4.6)